### PR TITLE
Add StringSource support for duct.core.resource.Resource

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [duct/core "0.6.2"]
+                 [duct/core "0.7.0-beta2"]
                  [duct/logger "0.2.1"]
-                 [integrant "0.6.3"]
+                 [integrant "0.7.0"]
                  [pandect "0.6.1"]
                  [ragtime "0.7.2"]]
   :profiles

--- a/src/duct/migrator/ragtime.clj
+++ b/src/duct/migrator/ragtime.clj
@@ -26,6 +26,8 @@
   String
   (get-string [s] s)
   java.net.URL
+  (get-string [s] (slurp s))
+  duct.core.resource.Resource
   (get-string [s] (slurp s)))
 
 (defn- singularize [coll]


### PR DESCRIPTION
Duct core 0.7.0-beta2 introduced the Resource record type which caused
an issue with the StringSource protocol when trying to use
#duct/resource. Adding duct.core.resource.Resource to the protocol
resolves it.

Fixes duct-framework/duct#82