### PR TITLE
Add support for reading SQL migrations from directory

### DIFF
--- a/src/duct/migrator/ragtime.clj
+++ b/src/duct/migrator/ragtime.clj
@@ -87,3 +87,7 @@
                            :up   (mapv get-string up)
                            :down (mapv get-string down)})
       (add-hash-to-id)))
+
+(defmethod ig/init-key ::dir [_ {:keys [path]}]
+  (->> (jdbc/load-resources path)
+       (map add-hash-to-id)))


### PR DESCRIPTION
This commit adds `:duct.migrator.ragtime/dir` key.
It allows to define all migrations in a dedicated directory and include
all migration by using one key inherinting from
`:duct.migrator.ragtime/dir`. Example:

    [:duct.migrator.ragtime/dir :todo.migrations/all]
    {:path "migrations"}

    :duct.migrator/ragtime
    {:migrations #ig/ref :todo.migrations/all}

This way we can rely on a list of up/down files, keeping the same
behaviour of rolling migrations back and reapplying them if the SQL at
the file changes.

Without this change, the only way to make this that way is to use
`ragtime.jdbc/load-resources` and implement hashing from scratch
(since `duct.migrator.ragtime/add-hash-to-id` is a private function).
Knowing that hashing is already done for `duct.migrator.ragtime/sql`
I thought the best way would be to add a dedicated keyword for
migrations from a directory.