### PR TITLE
Update ragtime and transient jdbc dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,8 @@
                  [duct/logger "0.3.0"]
                  [integrant "0.8.0"]
                  [pandect "0.6.1"]
-                 [ragtime "0.8.0"]]
+                 [ragtime "0.9.1"]]
   :profiles
   {:dev {:dependencies [[duct/database.sql "0.1.0"]
-                        [org.clojure/java.jdbc "0.7.11"]
+                        [org.clojure/java.jdbc "0.7.12"]
                         [org.xerial/sqlite-jdbc "3.30.1"]]}})


### PR DESCRIPTION
Dear @weavejester 

First, let me say thank you very much for your great duct framework :pray: 

In one of my projects, I realized that using the current `module.sql` yields to JDBC version 0.5.8 from 2016. `module.sql` uses `migrator.ragtime` which uses `ragtime`. The latest `ragtime` tag already uses the latest JDBC version. Hence, only dependencies in `migrator.ragtime` and then `module.sql` need to be bumped to see the benefits of a current JDBC library.

Looking forward to the change and thank you, again! 